### PR TITLE
feat: Rename WebSearch skill to Tavily throughout the codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",


### PR DESCRIPTION
## Summary
- Replaced all occurrences of "WebSearch" with "Tavily" in agents.json
- Updated skills arrays for both browserbase and xpander-ai agents
- This completes the renaming task as requested in issue #1

## Changes Made
- Updated browserbase agent skills in agents.json to use "Tavily"
- Updated perplexity agent skills in agents.json to use "Tavily"

## Test plan
- [x] Verify all WebSearch references are replaced with Tavily
- [x] Check that agents.json remains valid JSON
- [ ] Test that applications using this API handle the Tavily skill correctly

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)