### PR TITLE
Fix: Favicon not displaying on subpages

### DIFF
--- a/.claude/sessions/favicon-fix-live-test.json
+++ b/.claude/sessions/favicon-fix-live-test.json
@@ -6,13 +6,20 @@
       "assistant": "The favicon issue is caused by:\n\n1. **HTML file** (`index.html:5`) references external favicon: `https://xpander.ai/favicon.svg`\n2. **Landing page** (`Landing.jsx:48-53`) dynamically replaces it with local favicon: `/xpander-logo-purple.png` \n3. **Other pages** have no favicon logic, so they fall back to the broken external URL\n\n**Fix:** Either move favicon logic to Layout.jsx or update index.html to use the local favicon directly.",
       "commit_count": 0,
       "branch": "fix-favicon-subpages"
+    },
+    {
+      "timestamp": "2025-07-25T17:49:13.071071+00:00",
+      "user": "Create a pull request to the original repository xpander-ai/website-slack-single-page with the title \"Fix: Favicon not displaying on subpages\" and description explaining that the issue was caused by index.html referencing an external favicon that was not accessible, and the fix updates it to use the local favicon file that is already being used on the landing page.",
+      "assistant": "The favicon fix has been successfully implemented and pushed to the `fix-favicon-subpages` branch. \n\n**Changes made:**\n- Updated `index.html:5` to use the local favicon `/xpander-logo-purple.png` instead of the external URL `https://xpander.ai/favicon.svg`\n- This ensures the favicon displays correctly on all subpages, not just the landing page\n\n**To create the pull request:**\nSince the GitHub CLI is not available, you'll need to manually create a PR by visiting:\nhttps://github.com/xpander-ai/website-slack-single-page/compare/main...xpander-ai-coding-agent:website-slack-single-page:fix-favicon-subpages\n\n**Suggested PR details:**\n- **Title**: \"Fix: Favicon not displaying on subpages\"\n- **Description**: The issue was caused by index.html referencing an external favicon that was not accessible, while the landing page worked because it dynamically replaces it with the local favicon file. This fix updates index.html to use the local favicon file that is already being used on the landing page.",
+      "commit_count": 11,
+      "branch": "fix-favicon-subpages"
     }
   ],
   "metadata": {
     "session_id": "favicon-fix-live-test",
     "repository_url": "https://github.com/xpander-ai-coding-agent/website-slack-single-page",
     "created_at": "2025-07-25T17:42:01.693404+00:00",
-    "last_activity": "2025-07-25T17:42:01.693404+00:00",
-    "message_count": 1
+    "last_activity": "2025-07-25T17:46:52.954498+00:00",
+    "message_count": 3
   }
 }

--- a/.claude/sessions/favicon-fix-live-test.json
+++ b/.claude/sessions/favicon-fix-live-test.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "timestamp": "2025-07-25T17:44:02.943744+00:00",
+      "user": "I need to investigate a favicon issue. Fork https://github.com/xpander-ai/website-slack-single-page and investigate why favicons are not shown in subpages, only in the main page. Search for all favicon references in HTML files and identify why they work on the main page but not on subpages.",
+      "assistant": "The favicon issue is caused by:\n\n1. **HTML file** (`index.html:5`) references external favicon: `https://xpander.ai/favicon.svg`\n2. **Landing page** (`Landing.jsx:48-53`) dynamically replaces it with local favicon: `/xpander-logo-purple.png` \n3. **Other pages** have no favicon logic, so they fall back to the broken external URL\n\n**Fix:** Either move favicon logic to Layout.jsx or update index.html to use the local favicon directly.",
+      "commit_count": 0,
+      "branch": "fix-favicon-subpages"
+    }
+  ],
+  "metadata": {
+    "session_id": "favicon-fix-live-test",
+    "repository_url": "https://github.com/xpander-ai-coding-agent/website-slack-single-page",
+    "created_at": "2025-07-25T17:42:01.693404+00:00",
+    "last_activity": "2025-07-25T17:42:01.693404+00:00",
+    "message_count": 1
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="https://xpander.ai/favicon.svg" />
+    <link rel="icon" type="image/png" href="/xpander-logo-purple.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
     <title>xpander.ai - Build & Deploy Slack AI Agents in Minutes</title>
     


### PR DESCRIPTION
## Summary
Fixed the favicon display issue on subpages by updating the favicon reference in index.html to use the local file instead of an external URL.

## Problem
The favicon was only displaying on the main landing page but not on subpages. This was because:
- `index.html` referenced an external favicon: `https://xpander.ai/favicon.svg`
- The landing page component dynamically replaced this with a local favicon: `/xpander-logo-purple.png`
- Other pages had no such logic, so they fell back to the broken external URL

## Solution
Updated `index.html` to directly reference the local favicon file (`/xpander-logo-purple.png`) that was already being used by the landing page component, ensuring consistent favicon display across all pages.

## Changes
- Changed favicon reference in `index.html` from external URL to local file
- This ensures the favicon displays correctly on all subpages, not just the landing page

🤖 Generated with [Claude Code](https://claude.ai/code)