### PR TITLE
fix(#1): WebSearch skill should be renamed to Tavily

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",


### PR DESCRIPTION
## Summary

This PR addresses issue #1: **WebSearch skill should be renamed to Tavily**

The current skill name 'WebSearch' should be changed to 'Tavily' to better reflect the actual search service being used. This would make it clearer for users what search provider is powering the web s...

## Changes Made

- ✅ Issue resolved! I've successfully renamed all instances of "WebSearch" to "Tavily" in:  

## Technical Details

- **Files changed**: 2
- **Lines added**: 3
- **Lines removed**: 3

## Testing

The changes have been implemented and tested according to the issue requirements.

## Related Issue

Closes #1

---

<div align="center">
  <p>
    <strong>Written by <a href="https://github.com/xpander-ai-coding-agent">Xpander Coding Agent</a></strong>
  </p>
  <p>
    <em>Powered by Claude 3 Sonnet on <a href="https://xpander.ai">xpander.ai</a></em>
  </p>
</div>