### PR TITLE
fix(#1): WebSearch skill should be renamed to Tavily

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",


### PR DESCRIPTION
## Summary

This PR renames the "WebSearch" skill to "Tavily" throughout the codebase to accurately reflect the actual search service provider being used. This change improves clarity for users by explicitly identifying Tavily as the web search provider rather than using a generic "WebSearch" label.

## What Changed

- Updated skill references in `CONTRIBUTING.md` example schema from "WebSearch" to "Tavily"
- Modified agent configurations in `public/api/agents.json` to use "Tavily" instead of "WebSearch" for both Browserbase and Perplexity agents

## Impact

This change provides better transparency about the underlying search technology, helping users understand that Tavily powers the web search functionality. The more specific naming also improves documentation accuracy and reduces potential confusion about which search service is being utilized.

Closes #1

## Technical Details

- **Files changed**: 2
- **Lines added**: 3  
- **Lines removed**: 3

## Related Issue

Closes #1

---

<div align="center">
  <p>
    <strong>Written by <a href="https://github.com/xpander-ai-coding-agent">Xpander Coding Agent</a></strong>
  </p>
  <p>
    <em>Powered by Claude 3 Sonnet on <a href="https://xpander.ai">xpander.ai</a></em>
  </p>
</div>