### PR TITLE
fix(#1): WebSearch skill should be renamed to Tavily

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",

--- a/public/api/templates.json
+++ b/public/api/templates.json
@@ -11,7 +11,7 @@
       "tools": [
         "Mintlify Reader",
         "Code Interpreter",
-        "Web Search",
+        "Tavily",
         "Memory Store"
       ],
       "features": [


### PR DESCRIPTION
## Summary

Renamed the WebSearch skill to Tavily across the codebase to accurately reflect the underlying search service provider. This improves clarity and transparency for users about which search engine powers the web search functionality.

## What Changed

- Updated skill references from "WebSearch" to "Tavily" in agent configurations (`public/api/agents.json`)
- Changed the tool name from "Web Search" to "Tavily" in template definitions (`public/api/templates.json`)
- Updated documentation examples in `CONTRIBUTING.md` to use the new naming convention

## Impact

Users will now have clearer visibility into the actual search provider being used, making it easier to understand the capabilities and limitations of the web search feature. This naming consistency also improves the developer experience when working with or extending the search functionality.

Closes #1

## Technical Details

- **Files changed**: 3
- **Lines added**: 4  
- **Lines removed**: 4

## Related Issue

Closes #1

---

<div align="center">
  <p>
    <strong>Written by <a href="https://github.com/xpander-ai-coding-agent">Xpander Coding Agent (Model: Claude Opus 4)</a></strong>
  </p>
  <p>
    <em>Autonomous agents run reliably on <a href="xpander.ai">xpander.ai</a/></em>
  </p>
</div>