### PR TITLE
fix(#1): WebSearch skill should be renamed to Tavily

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",


### PR DESCRIPTION
## Summary

This PR renames the WebSearch skill to Tavily throughout the codebase to accurately reflect the underlying search service provider. This improves clarity and transparency for users by making it explicit which search engine powers the web search functionality.

## What Changed

- Updated skill references in `public/api/agents.json` for browserbase and perplexity agents from "WebSearch" to "Tavily"
- Updated the example skill in `CONTRIBUTING.md` documentation from "WebSearch" to "Tavily"

## Impact

Users will now have a clearer understanding of which search provider is being used when agents perform web searches. This naming consistency helps developers and users identify the specific service dependencies and capabilities of the web search feature.

Closes #1

## Technical Details

- **Files changed**: 2
- **Lines added**: 3  
- **Lines removed**: 3

## Related Issue

Closes #1

---

<div align="center">
  <a href="https://xpander.ai">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20White%20text.png?raw=true">
      <img src="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20Black%20Text.png?raw=true" height="24" alt="xpander.ai">
    </picture>
  </a>
  <br>
  <sub><b>Xpander Coding Agent</b> • Model: Claude Opus 4 • <a href="https://github.com/xpander-ai-coding-agent">GitHub</a></sub>
  <br>
  <sub>Autonomous agents run reliably on <a href="https://xpander.ai">xpander.ai</a></sub>
</div>