### PR TITLE
fix(#1): WebSearch skill should be renamed to Tavily

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For developers comfortable with Git:
   "author": "Your Name or Company",
   "authorLink": "https://your-website.com",
   "logo": "/logos/your-logo.png",
-  "skills": ["Mintlify", "WebSearch", "etc"],
+  "skills": ["Mintlify", "Tavily", "etc"],
   "capabilities": [
     "Key capability 1",
     "Key capability 2",

--- a/public/api/agents.json
+++ b/public/api/agents.json
@@ -9,7 +9,7 @@
       "author": "xpander.ai",
       "authorLink": "https://browserbase.com",
       "logo": "/logos/browserbase.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://browserbase.com/agent",
       "capabilities": [
         "Answer questions from Browserbase documentation",
@@ -51,7 +51,7 @@
       "author": "xpander.ai",
       "authorLink": "https://perplexity.ai",
       "logo": "/logos/perplexity.png",
-      "skills": ["Mintlify", "WebSearch"],
+      "skills": ["Mintlify", "Tavily"],
       "a2aUrl": "https://perplexity.ai/agent",
       "capabilities": [
         "Answer questions from Perplexity documentation",


### PR DESCRIPTION
## Summary

This PR renames the WebSearch skill to Tavily throughout the codebase to better reflect the actual search service being used. This improves clarity and transparency for users by explicitly identifying the search provider powering the web search functionality.

## What Changed

- Updated skill name from "WebSearch" to "Tavily" in `CONTRIBUTING.md` documentation
- Renamed the skill in two agent configurations within `public/api/agents.json`
- Total of 3 occurrences updated across 2 files

## Impact

Users will now have a clearer understanding of which search service is being utilized when they interact with web search capabilities. This naming convention aligns with the principle of transparency in tooling and helps users make informed decisions about the services they're using.

## Technical Details

- **Files changed**: 2
- **Lines added**: 3  
- **Lines removed**: 3

## Related Issue

Closes #1

---

<div align="center">
  <a href="https://xpander.ai">
    <picture>
      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20White%20text.png?raw=true">
      <img src="https://github.com/xpander-ai/xpander.ai/blob/main/images/Purple%20Logo%20Black%20Text.png?raw=true" height="24" alt="xpander.ai">
    </picture>
  </a>
  <br>
  <sub><b>Xpander Coding Agent</b> • Model: Claude Opus 4 • <a href="https://github.com/xpander-ai-coding-agent">GitHub</a></sub>
  <br>
  <sub>Autonomous agents run reliably on <a href="https://xpander.ai">xpander.ai</a></sub>
</div>